### PR TITLE
добавил возможность выполнять миграции из указанного модуля, с возмож…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Created by .ignore support plugin (hsz.mobi)
+/.idea/
+/vendor/*
+/composer.lock

--- a/YiiMigrate/AConsoleApplication.php
+++ b/YiiMigrate/AConsoleApplication.php
@@ -6,4 +6,5 @@ use \Yii;
 
 class AConsoleApplication extends \CConsoleApplication {
   public $migrateModules;
+  public $migrateSystem;
 }

--- a/config/migration.php-default
+++ b/config/migration.php-default
@@ -17,5 +17,8 @@ return array(
   'migrateModules' => array(
     //'module' => 'relative.dotted..module.path'
   ),
+  'migrateSystem' => array(
+    //'component' => 'relative.dotted..module.path'
+  ),
   //'templateFile' => 'some/custom/path/relative/to/application/root'
 );


### PR DESCRIPTION
…ностью выполнять миграции из модулей. не указанных в конфиге. Нужно для выполнения служебных миграций, которые не должны быть доступны по дефолту и не могут выполняться/откатываться автоматически при сборках например.

Нат, хочу юзать вызов миграций из нужных мест для запуска инитных миграций для новых тестовых сред, которые не хотелось бы путать со всеми остальными мигрухами. Имею желание положить их в корень проекта куда-нибудь в init/migrations но как модуль его не указывать нигде. Пока придумалось такое решение. Можно перебрать как-то иначе, посмотри плз

Заодно пофиксил ошибку с выборкой миграций новых - не учитывался модуль при выборке.
